### PR TITLE
[#178347236] Ansible: Wiederhole den Plugindownload bis zu 5 mal

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,9 +33,15 @@
     - Restart Grafana
 
 
+# retry installation up to 5 times as download failes sometimes.
+# https://github.com/grafana/grafana/issues/13079
 - name: Install Plugins
   command: "grafana-cli plugins install {{ item.plugin_id }} {{ item.plugin_version|default('') }}"
   with_items: "{{ _grafana.plugins }}"
+  register: _plugin_install
+  until: _plugin_install is succeeded
+  retries: 5
+  delay: 2
   notify:
     - Restart Grafana
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,8 +38,8 @@
 - name: Install Plugins
   command: "grafana-cli plugins install {{ item.plugin_id }} {{ item.plugin_version|default('') }}"
   with_items: "{{ _grafana.plugins }}"
-  register: _plugin_install
-  until: _plugin_install is succeeded
+  register: plugins_installation
+  until: plugins_installation is succeeded
   retries: 5
   delay: 2
   notify:


### PR DESCRIPTION
- https://github.com/grafana/grafana/issues/13079
- Downloads schlagen manchmal fehl, breche nicht nach dem ersten Versuch ab.